### PR TITLE
Only build shared/static as requested by feature flags

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -71,7 +71,7 @@ jobs:
         shell: bash -el {0}
         run: cargo test ${{ matrix.flags }}
 
-  test-musl:
+  test-musllinux:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
         flags:
           - --features use-system-blosc2
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - uses: conda-incubator/setup-miniconda@v3
@@ -71,6 +71,22 @@ jobs:
         shell: bash -el {0}
         run: cargo test ${{ matrix.flags }}
 
+  test-musl:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cross
+        run: cargo install cross --git https://github.com/cross-rs/cross --rev 6d097fb
+
+      - name: Test
+        run: cross test --target x86_64-unknown-linux-musl --no-default-features --features static
+
   test-native:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -82,7 +98,7 @@ jobs:
           - windows-latest
           - ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ name = "blosc2"
 [features]
 default = ["shared"]
 use-system-blosc2 = ["blosc2-sys/use-system-blosc2"]
-static = []
-shared = []
+static = ["blosc2-sys/static"]
+shared = ["blosc2-sys/shared"]
 
 [dependencies]
 blosc2-sys = { path = "blosc2-sys", version = "0.2.3+2.14.3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ name = "blosc2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 default = ["shared"]
-use-system-blosc2 = ["shared", "blosc2-sys/use-system-blosc2"]
+use-system-blosc2 = ["blosc2-sys/use-system-blosc2"]
 static = []
 shared = []
 

--- a/blosc2-sys/build.rs
+++ b/blosc2-sys/build.rs
@@ -34,37 +34,17 @@ fn main() {
             cmake_conf.define("BUILD_SHARED", "ON");
         }
 
-        if cfg!(target_feature = "sse2") {
-            cmake_conf.define("SHUFFLE_SSE2_ENABLED", "1");
-            if cfg!(target_env = "msvc") {
-                if cfg!(target_pointer_width = "32") {
-                    cmake_conf.cflag("/arch:SSE2");
-                }
-            } else if cfg!(target_arch = "x86_64")
-                || cfg!(target_arch = "x86")
-                || cfg!(target_arch = "i686")
-            {
-                cmake_conf.cflag("-msse2");
-            }
-        }
-
-        if cfg!(target_feature = "avx2") {
-            cmake_conf.define("SHUFFLE_AVX2_ENABLED", "1");
-            if cfg!(target_env = "msvc") {
-                cmake_conf.cflag("/arch:AVX2");
-            } else if cfg!(target_arch = "x86_64")
-                || cfg!(target_arch = "x86")
-                || cfg!(target_arch = "i686")
-            {
-                cmake_conf.cflag("-mavx2");
-            }
-        }
-
         if std::env::var("BLOSC2_INSTALL_PREFIX").is_ok() {
             let install_prefix = format!("{}", install_path.display());
             cmake_conf
                 .define("CMAKE_INSTALL_PREFIX", install_prefix)
                 .define("BLOSC_INSTALL", "ON");
+        }
+
+        // Solves undefined reference to __cpu_model when using __builtin_cpu_supports() in shuffle.c
+        if let Ok(true) = std::env::var("CARGO_CFG_TARGET_ENV").map(|v| v == "musl") {
+            // TODO: maybe not always libgcc? I'm not sure.
+            println!("cargo:rustc-link-lib=gcc");
         }
 
         cmake_conf.build();

--- a/blosc2-sys/build.rs
+++ b/blosc2-sys/build.rs
@@ -20,12 +20,19 @@ fn main() {
             .define("BUILD_FUZZERS", "OFF")
             .define("BUILD_BENCHMARKS", "OFF")
             .define("BUILD_EXAMPLES", "OFF")
-            .define("BUILD_STATIC", "ON")
-            .define("BUILD_SHARED", "ON")
+            .define("BUILD_STATIC", "OFF")
+            .define("BUILD_SHARED", "OFF")
             .define("BUILD_TESTS", "OFF")
             .define("BUILD_PLUGINS", "OFF")
             .define("CMAKE_C_FLAGS", cmake_c_flags)
             .always_configure(true);
+
+        if cfg!(feature = "static") {
+            cmake_conf.define("BUILD_STATIC", "ON");
+        }
+        if cfg!(feature = "shared") {
+            cmake_conf.define("BUILD_SHARED", "ON");
+        }
 
         if cfg!(target_feature = "sse2") {
             cmake_conf.define("SHUFFLE_SSE2_ENABLED", "1");


### PR DESCRIPTION
- Have blosc2-rs default to shared, but only build what is requested (static and/or shared)
- Add failing musllinx test job which fails w/
```
  = note: /usr/local/bin/../lib/gcc/x86_64-linux-musl/9.2.0/../../../../x86_64-linux-musl/bin/ld: /target/x86_64-unknown-linux-musl/debug/build/blosc2-sys-26ea9756417d6d3d/out/lib/libblosc2.a(shuffle.c.o): in function `blosc_get_cpu_features':
          /home/milesg/Projects/blosc2-rs/blosc2-sys/c-blosc2/blosc/shuffle.c:99: undefined reference to `__cpu_model'
          /usr/local/bin/../lib/gcc/x86_64-linux-musl/9.2.0/../../../../x86_64-linux-musl/bin/ld: /home/milesg/Projects/blosc2-rs/blosc2-sys/c-blosc2/blosc/shuffle.c:102: undefined reference to `__cpu_model'
          /usr/local/bin/../lib/gcc/x86_64-linux-musl/9.2.0/../../../../x86_64-linux-musl/bin/ld: /home/milesg/Projects/blosc2-rs/blosc2-sys/c-blosc2/blosc/shuffle.c:105: undefined reference to `__cpu_model'
          /usr/local/bin/../lib/gcc/x86_64-linux-musl/9.2.0/../../../../x86_64-linux-musl/bin/ld: /home/milesg/Projects/blosc2-rs/blosc2-sys/c-blosc2/blosc/shuffle.c:105: undefined reference to `__cpu_model'
          collect2: error: ld returned 1 exit status
```
xref: https://github.com/Blosc/c-blosc2/issues/602