### PR TITLE
Fix crates build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blosc2-rs"
-version = "0.2.3+2.14.3"
+version = "0.2.4+2.14.3"
 description = "Blosc2"
 license = "MIT"
 edition = "2021"

--- a/blosc2-sys/Cargo.toml
+++ b/blosc2-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blosc2-sys"
-version = "0.2.3+2.14.3"
+version = "0.2.4+2.14.3"
 edition = "2021"
 description = "Bindings to C Blosc2"
 license = "MIT"
@@ -33,3 +33,4 @@ regenerate-bindings = ["bindgen"]
 cmake = "^0.1"
 bindgen = { version = "^0.64", optional = true }
 pkg-config = { version = "^0.3", optional = true }
+copy_dir = "0.1.3"

--- a/blosc2-sys/build.rs
+++ b/blosc2-sys/build.rs
@@ -7,13 +7,20 @@ fn main() {
     #[cfg(not(feature = "use-system-blosc2"))]
     {
         let out_dir_str = std::env::var("OUT_DIR").unwrap();
+        let out_dir = Path::new(&out_dir_str);
+
+        // The configure step modifies the config.h.in file into c-blosc2/config.h
+        // which violates the cargo publishing/build as it modifies things outside
+        // of the crate's out dir; so we'll copy everything into out/c-blosc2
+        let src_dir = out_dir.join("c-blosc2");
+        copy_dir::copy_dir("c-blosc2", &src_dir).unwrap();
 
         let install_path_str =
             std::env::var("BLOSC2_INSTALL_PREFIX").unwrap_or(out_dir_str.to_owned());
         let install_path = Path::new(&install_path_str);
 
         let cmake_c_flags = std::env::var("CFLAGS").unwrap_or("".to_string());
-        let mut cmake_conf = cmake::Config::new("c-blosc2");
+        let mut cmake_conf = cmake::Config::new(src_dir);
         cmake_conf
             .define("CMAKE_POSITION_INDEPENDENT_CODE", "ON")
             .define("BUILD_SHARED_LIBS", "ON")

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,0 @@
-fn main() {
-    #[cfg(feature = "static")]
-    println!("cargo:rustc-link-lib=static=blosc2");
-
-    #[cfg(feature = "shared")]
-    println!("cargo:rustc-link-lib=blosc2");
-}


### PR DESCRIPTION
Currently fails to build on docs due to c-blosc2 configure step modifying files outside of it's OUT_DIR. 
Specifically this is the c-blosc2/config.h.in -> c-blosc2/config.h

Solution here is to just copy the c-blosc2 directory into the OUT_DIR and use that instead of the submodule directly.