### PR TITLE
Fix OSX x86_64 static build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -118,4 +118,4 @@ jobs:
       - name: Test (static)
         # mac fails w/ missing symbol __cpu_model, not sure yet
         # windows fails on the --doc portion of tests
-        run: cargo test --no-default-features --features static
+        run: cargo test --no-default-features --features static -vv

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,81 +11,81 @@ on:
       - prereleased
 
 jobs:
-  # test-conda-env:
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       os:
-  #         - macos-14
-  #         - windows-latest
-  #         - ubuntu-latest
-  #       flags:
-  #         - --features use-system-blosc2
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         submodules: recursive
-  #     - uses: conda-incubator/setup-miniconda@v3
-  #       with:
-  #         python-version: 3.12
-  #         mamba-version: "*"
-  #         channels: conda-forge,defaults
-  #         channel-priority: true
-  #         activate-environment: blosc2
-  #         environment-file: environment.yml
-  #     - shell: bash -el {0}
-  #       run: |
-  #         conda info
-  #         conda list
-  #         conda config --show-sources
-  #         conda config --show
-  #         printenv | sort
-  #     - name: Install Rust toolchain
-  #       uses: dtolnay/rust-toolchain@stable
+  test-conda-env:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-14
+          - windows-latest
+          - ubuntu-latest
+        flags:
+          - --features use-system-blosc2
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          python-version: 3.12
+          mamba-version: "*"
+          channels: conda-forge,defaults
+          channel-priority: true
+          activate-environment: blosc2
+          environment-file: environment.yml
+      - shell: bash -el {0}
+        run: |
+          conda info
+          conda list
+          conda config --show-sources
+          conda config --show
+          printenv | sort
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
 
-  #     - name: Install packages (macOS)
-  #       if: runner.os == 'macOS'
-  #       run: brew install ninja
+      - name: Install packages (macOS)
+        if: runner.os == 'macOS'
+        run: brew install ninja
 
-  #     - name: Install packages (Windows)
-  #       if: runner.os == 'Windows'
-  #       run: choco install ninja
+      - name: Install packages (Windows)
+        if: runner.os == 'Windows'
+        run: choco install ninja
 
-  #     - name: Install packages (Ubuntu)
-  #       if: runner.os == 'Linux'
-  #       shell: bash -el {0}
-  #       run: conda install clang -y
+      - name: Install packages (Ubuntu)
+        if: runner.os == 'Linux'
+        shell: bash -el {0}
+        run: conda install clang -y
 
-  #     - name: Build
-  #       shell: bash -el {0}
-  #       run: cargo build ${{ matrix.flags }}
+      - name: Build
+        shell: bash -el {0}
+        run: cargo build ${{ matrix.flags }}
 
-  #     - name: Test
-  #       # Running tests using shared library is ugly since conda doesn't
-  #       # update LD_LIBRARY_PATH type env vars, so would manually need to 
-  #       # set the library to a currently discoverable place or update these
-  #       # env vars for each platform. Won't automatically locate the blosc2 
-  #       # shared library within the conda environment.
-  #       if: ${{ matrix.flags == '--features static' }}
-  #       shell: bash -el {0}
-  #       run: cargo test ${{ matrix.flags }}
+      - name: Test
+        # Running tests using shared library is ugly since conda doesn't
+        # update LD_LIBRARY_PATH type env vars, so would manually need to 
+        # set the library to a currently discoverable place or update these
+        # env vars for each platform. Won't automatically locate the blosc2 
+        # shared library within the conda environment.
+        if: ${{ matrix.flags == '--features static' }}
+        shell: bash -el {0}
+        run: cargo test ${{ matrix.flags }}
 
-  # test-musllinux:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         submodules: recursive
+  test-musllinux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
-  #     - name: Install Rust toolchain
-  #       uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
 
-  #     - name: Install cross
-  #       run: cargo install cross --git https://github.com/cross-rs/cross --rev 6d097fb
+      - name: Install cross
+        run: cargo install cross --git https://github.com/cross-rs/cross --rev 6d097fb
 
-  #     - name: Test
-  #       run: cross test --target x86_64-unknown-linux-musl --no-default-features --features static
+      - name: Test
+        run: cross test --target x86_64-unknown-linux-musl --no-default-features --features static
 
   test-native:
     runs-on: ${{ matrix.os }}
@@ -94,9 +94,9 @@ jobs:
       matrix:
         os:
           - macos-13  # x86_64
-          # - macos-14  # M1
+          - macos-14  # M1
           - windows-latest
-          # - ubuntu-latest
+          - ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -112,10 +112,10 @@ jobs:
           echo "MACOSX_DEPLOYMENT_TARGET=10.12" >> $GITHUB_ENV
 
       # Known issue where testing w/ shared linked lib doesn't work with --doc testing
-      # - name: Test (shared)
-      #   run: cargo test --features shared --lib
+      - name: Test (shared)
+        run: cargo test --features shared --lib -vv
 
       - name: Test (static)
-        # mac fails w/ missing symbol __cpu_model, not sure yet
-        # windows fails on the --doc portion of tests
-        run: cargo test --no-default-features --features static -vv
+        run: |
+          cargo clean  # ensure we're starting fresh, no funny business
+          cargo test --no-default-features --features static -vv

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,81 +11,81 @@ on:
       - prereleased
 
 jobs:
-  test-conda-env:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - macos-14
-          - windows-latest
-          - ubuntu-latest
-        flags:
-          - --features use-system-blosc2
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - uses: conda-incubator/setup-miniconda@v3
-        with:
-          python-version: 3.12
-          mamba-version: "*"
-          channels: conda-forge,defaults
-          channel-priority: true
-          activate-environment: blosc2
-          environment-file: environment.yml
-      - shell: bash -el {0}
-        run: |
-          conda info
-          conda list
-          conda config --show-sources
-          conda config --show
-          printenv | sort
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+  # test-conda-env:
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os:
+  #         - macos-14
+  #         - windows-latest
+  #         - ubuntu-latest
+  #       flags:
+  #         - --features use-system-blosc2
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         submodules: recursive
+  #     - uses: conda-incubator/setup-miniconda@v3
+  #       with:
+  #         python-version: 3.12
+  #         mamba-version: "*"
+  #         channels: conda-forge,defaults
+  #         channel-priority: true
+  #         activate-environment: blosc2
+  #         environment-file: environment.yml
+  #     - shell: bash -el {0}
+  #       run: |
+  #         conda info
+  #         conda list
+  #         conda config --show-sources
+  #         conda config --show
+  #         printenv | sort
+  #     - name: Install Rust toolchain
+  #       uses: dtolnay/rust-toolchain@stable
 
-      - name: Install packages (macOS)
-        if: runner.os == 'macOS'
-        run: brew install ninja
+  #     - name: Install packages (macOS)
+  #       if: runner.os == 'macOS'
+  #       run: brew install ninja
 
-      - name: Install packages (Windows)
-        if: runner.os == 'Windows'
-        run: choco install ninja
+  #     - name: Install packages (Windows)
+  #       if: runner.os == 'Windows'
+  #       run: choco install ninja
 
-      - name: Install packages (Ubuntu)
-        if: runner.os == 'Linux'
-        shell: bash -el {0}
-        run: conda install clang -y
+  #     - name: Install packages (Ubuntu)
+  #       if: runner.os == 'Linux'
+  #       shell: bash -el {0}
+  #       run: conda install clang -y
 
-      - name: Build
-        shell: bash -el {0}
-        run: cargo build ${{ matrix.flags }}
+  #     - name: Build
+  #       shell: bash -el {0}
+  #       run: cargo build ${{ matrix.flags }}
 
-      - name: Test
-        # Running tests using shared library is ugly since conda doesn't
-        # update LD_LIBRARY_PATH type env vars, so would manually need to 
-        # set the library to a currently discoverable place or update these
-        # env vars for each platform. Won't automatically locate the blosc2 
-        # shared library within the conda environment.
-        if: ${{ matrix.flags == '--features static' }}
-        shell: bash -el {0}
-        run: cargo test ${{ matrix.flags }}
+  #     - name: Test
+  #       # Running tests using shared library is ugly since conda doesn't
+  #       # update LD_LIBRARY_PATH type env vars, so would manually need to 
+  #       # set the library to a currently discoverable place or update these
+  #       # env vars for each platform. Won't automatically locate the blosc2 
+  #       # shared library within the conda environment.
+  #       if: ${{ matrix.flags == '--features static' }}
+  #       shell: bash -el {0}
+  #       run: cargo test ${{ matrix.flags }}
 
-  test-musllinux:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
+  # test-musllinux:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         submodules: recursive
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+  #     - name: Install Rust toolchain
+  #       uses: dtolnay/rust-toolchain@stable
 
-      - name: Install cross
-        run: cargo install cross --git https://github.com/cross-rs/cross --rev 6d097fb
+  #     - name: Install cross
+  #       run: cargo install cross --git https://github.com/cross-rs/cross --rev 6d097fb
 
-      - name: Test
-        run: cross test --target x86_64-unknown-linux-musl --no-default-features --features static
+  #     - name: Test
+  #       run: cross test --target x86_64-unknown-linux-musl --no-default-features --features static
 
   test-native:
     runs-on: ${{ matrix.os }}
@@ -94,9 +94,9 @@ jobs:
       matrix:
         os:
           - macos-13  # x86_64
-          - macos-14  # M1
+          # - macos-14  # M1
           - windows-latest
-          - ubuntu-latest
+          # - ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -107,14 +107,15 @@ jobs:
 
       - name: Set Environment Variables
         if: runner.os == 'macOS'
-        run: echo "MACOSX_DEPLOYMENT_TARGET=$(sw_vers -productVersion)" >> $GITHUB_ENV
+        run: |
+          # echo "MACOSX_DEPLOYMENT_TARGET=$(sw_vers -productVersion)" >> $GITHUB_ENV
+          echo "MACOSX_DEPLOYMENT_TARGET=10.12" >> $GITHUB_ENV
 
       # Known issue where testing w/ shared linked lib doesn't work with --doc testing
-      - name: Test (shared)
-        run: cargo test --features shared --lib
+      # - name: Test (shared)
+      #   run: cargo test --features shared --lib
 
       - name: Test (static)
         # mac fails w/ missing symbol __cpu_model, not sure yet
         # windows fails on the --doc portion of tests
-        if: matrix.os != 'macos-13' && matrix.os != 'windows-latest'
         run: cargo test --no-default-features --features static

--- a/blosc2-sys/build.rs
+++ b/blosc2-sys/build.rs
@@ -58,7 +58,7 @@ fn main() {
 
         for subdir in &["lib64", "lib", "bin"] {
             let search_path = install_path.join(subdir);
-            println!("cargo::rustc-link-search={}", search_path.display());
+            println!("cargo:rustc-link-search=native={}", search_path.display());
         }
     }
 
@@ -70,7 +70,7 @@ fn main() {
                 let install_path = Path::new(&prefix);
                 for subdir in &["lib64", "lib", "bin"] {
                     let search_path = install_path.join(subdir);
-                    println!("cargo::rustc-link-search={}", search_path.display());
+                    println!("cargo:rustc-link-search={}", search_path.display());
                 }
             }
 

--- a/blosc2-sys/build.rs
+++ b/blosc2-sys/build.rs
@@ -88,8 +88,15 @@ fn main() {
         }
     }
 
+    #[allow(unused_variables)]
+    let libname = if cfg!(target_os = "windows") {
+        "libblosc2"
+    } else {
+        "blosc2"
+    };
+
     #[cfg(feature = "static")]
-    println!("cargo:rustc-link-lib=static=blosc2");
+    println!("cargo:rustc-link-lib=static={}", libname);
 
     #[cfg(feature = "shared")]
     println!("cargo:rustc-link-lib=blosc2");


### PR DESCRIPTION
Hrm, 'fixed' the x86_64 OSX error or "invalid use of rip-relative addressing..." by using my fork and this commit: https://github.com/milesgranger/c-blosc2/commit/4b9259ff0089ea6a89ac98fec2154707e603901a

Good w/ it for now.. maybe try to upstream it or just rebase on following c-blosc2 releases.