### PR TITLE
Add missing import for regenerate-bindings feature

### DIFF
--- a/blosc2-sys/build.rs
+++ b/blosc2-sys/build.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 fn main() {
     println!("cargo::rerun-if-changed=build.rs");


### PR DESCRIPTION
Fixes:

```
error[E0433]: failed to resolve: use of undeclared type `PathBuf`
   --> build.rs:107:19
    |
107 |         let out = PathBuf::from(&(format!("{}/bindings.rs", std::env::var("OUT_DIR").unwrap())));
    |                   ^^^^^^^ use of undeclared type `PathBuf`
    |
help: consider importing this struct
    |
1   + use std::path::PathBuf;
    |
```