### PR TITLE
Use a current version of bindgen

### DIFF
--- a/blosc2-sys/Cargo.toml
+++ b/blosc2-sys/Cargo.toml
@@ -31,6 +31,6 @@ regenerate-bindings = ["bindgen"]
 
 [build-dependencies]
 cmake = "^0.1"
-bindgen = { version = "^0.64", optional = true }
+bindgen = { version = "^0.69", optional = true }
 pkg-config = { version = "^0.3", optional = true }
 copy_dir = "0.1.3"

--- a/blosc2-sys/build.rs
+++ b/blosc2-sys/build.rs
@@ -112,7 +112,7 @@ fn main() {
             .header("c-blosc2/include/blosc2.h")
             // Tell cargo to invalidate the built crate whenever any of the
             // included header files changed.
-            .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+            .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
             .blocklist_type("__uint64_t_")
             .blocklist_type("__size_t")
             .blocklist_item("BLOSC2_[C|D]PARAMS_DEFAULTS")


### PR DESCRIPTION
Update bindgen from 0.64 to 0.69 and replace usage of the deprecated `bindgen::CargoCallbacks` constant.