### PR TITLE
Avoid an unused import warning in build.rs

### DIFF
--- a/blosc2-sys/build.rs
+++ b/blosc2-sys/build.rs
@@ -1,4 +1,6 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
+#[cfg(feature = "regenerate-bindings")]
+use std::path::PathBuf;
 
 fn main() {
     println!("cargo::rerun-if-changed=build.rs");


### PR DESCRIPTION
The PR https://github.com/milesgranger/blosc2-rs/pull/14 fixed the `regenerate-bindings` feature, but I accidentally introduced an unused import warning from `build.rs` when that feature is not enabled.

We can fix the warning by conditionalizing the import of `PathBuf` as in this PR. Alternatively, if you prefer, the import could be moved to the conditional block expression where it is used, like this:

```patch
--- a/blosc2-sys/build.rs
+++ b/blosc2-sys/build.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 fn main() {
     println!("cargo::rerun-if-changed=build.rs");
@@ -105,6 +105,7 @@ fn main() {
 
     #[cfg(feature = "regenerate-bindings")]
     {
+        use std::path::PathBuf;
         let out = PathBuf::from(&(format!("{}/bindings.rs", std::env::var("OUT_DIR").unwrap())));
         bindgen::Builder::default()
             // The input header we would like to generate
```