### PR TITLE
Exclude benchmarks and their data files from released crates (plus a few other files)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,12 @@ description = "Blosc2"
 license = "MIT"
 edition = "2021"
 exclude = [
+    ".gitignore",
+    ".gitmodules",
+    ".github/*",
     "benches/*",
     "data/*",
+    "environment.yml",
 ]
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.3.1+2.15.1"
 description = "Blosc2"
 license = "MIT"
 edition = "2021"
+exclude = [
+    "benches/*",
+    "data/*",
+]
 
 [lib]
 name = "blosc2"


### PR DESCRIPTION
Similarly to https://github.com/milesgranger/cramjam/issues/178, distributing the benchmark data on `crates.io` not only increases the size of the `blosc2-rs` crates a great deal, but some of the contents are subject to complicated or unclear license terms, which is an issue for those (such as distribution packagers) who would need to redistribute the source archive (`.crate` file).

While I was meddling with this, I also proposed excluding a few other files from the published crates that are harmless (small and with no license issues) but still unnecessary.