### PR TITLE
Bump version -> 0.4.0 and blosc2 -> 2.15.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blosc2-rs"
-version = "0.3.1+2.15.1"
+version = "0.4.0+2.15.2"
 description = "Blosc2"
 license = "MIT"
 edition = "2021"
@@ -31,7 +31,7 @@ prefer-external-lz4   = ["blosc2-sys/prefer-external-lz4"]
 deactivate-zlib-optim = ["blosc2-sys/deactivate-zlib-optim"]
 
 [dependencies]
-blosc2-sys = { path = "blosc2-sys", version = "0.3.1+2.15.1" }
+blosc2-sys = { path = "blosc2-sys", version = "0.4.0+2.15.2" }
 parking_lot = "^0.12"
 
 [dev-dependencies]

--- a/blosc2-sys/Cargo.toml
+++ b/blosc2-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blosc2-sys"
-version = "0.3.1+2.15.1"
+version = "0.4.0+2.15.2"
 edition = "2021"
 description = "Bindings to C Blosc2"
 license = "MIT"


### PR DESCRIPTION
Will close #33.

@musicinmybrain, I've tested libcramjam after this version bump and including changes done in #34 and it no longer seg faults... at least on my machine. :) 

I'll continue here and bump libcramjam after releasing blosc2-rs, but as you may have seen in cramjam (https://github.com/milesgranger/cramjam/pull/197), next release will exclude the experimental modules of blosc2, and the isal backed codecs (igzip, ideflate, izlib) as I've found myself on limited bandwidth this year to properly address the development of these further.